### PR TITLE
feat(minigames): casual side-game scoring with per-player frame tracking

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -2,7 +2,7 @@ export const revalidate = 300; // revalidate every 5 minutes
 
 import { createClient } from "@/lib/supabase-server";
 import Link from "next/link";
-import { ChevronUp, ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronRight, Dices } from "lucide-react";
 import type {
   ProfileRow,
   SessionWithGamesFramesAndProfile,
@@ -220,6 +220,23 @@ export default async function DashboardPage() {
         className="mb-5 block rounded-xl bg-gradient-to-r from-blue to-blue-dark py-4 text-center text-base font-bold text-white shadow-lg shadow-blue/25 transition-all duration-150 active:scale-[0.97]"
       >
         Log a Session
+      </Link>
+
+      {/* Minigames entry */}
+      <Link
+        href="/minigames"
+        className="glass mb-5 flex items-center gap-3 p-3 active:scale-[0.98]"
+      >
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple/15 text-purple">
+          <Dices size={20} />
+        </div>
+        <div className="flex-1">
+          <div className="text-sm font-bold">Minigames</div>
+          <p className="text-[11px] text-text-muted">
+            Casual side-game scoring — 2-2-3 and more
+          </p>
+        </div>
+        <ChevronRight size={14} className="shrink-0 text-text-muted/30" />
       </Link>
 
       {/* Activity Feed */}

--- a/src/app/(app)/minigames/page.tsx
+++ b/src/app/(app)/minigames/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Dices } from "lucide-react";
+import { useMinigameState } from "@/hooks/useMinigameState";
+import MinigameSetup from "@/components/minigame/MinigameSetup";
+import MinigameBoard from "@/components/minigame/MinigameBoard";
+import MinigameWinnerPicker from "@/components/minigame/MinigameWinnerPicker";
+import MinigameResults from "@/components/minigame/MinigameResults";
+
+export default function MinigamesPage() {
+  const mg = useMinigameState();
+  const { state } = mg;
+
+  const subtitle =
+    state.step === "setup"
+      ? "Casual side-game scoring"
+      : state.step === "playing"
+        ? "Tap each player as you bowl"
+        : "Session complete";
+
+  return (
+    <div>
+      <header className="mb-5 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple/15 text-purple">
+          <Dices size={22} />
+        </div>
+        <div>
+          <h1 className="text-xl font-extrabold leading-tight">Minigames</h1>
+          <p className="text-[13px] text-text-muted">{subtitle}</p>
+        </div>
+      </header>
+
+      {!mg.hydrated ? (
+        <div className="glass h-40 animate-pulse" />
+      ) : state.step === "setup" ? (
+        <MinigameSetup onStart={mg.startGame} />
+      ) : state.step === "playing" ? (
+        <>
+          <MinigameBoard
+            state={state}
+            onEvent={mg.addEvent}
+            onUndo={mg.undoPlayer}
+            onAdvance={mg.advancePlayer}
+            onGoToFrame={mg.goToFrame}
+            onEndGame={mg.requestEndGame}
+          />
+          {state.pickingWinner && (
+            <MinigameWinnerPicker
+              state={state}
+              onConfirm={mg.finishGame}
+              onCancel={mg.cancelEndGame}
+            />
+          )}
+        </>
+      ) : (
+        <MinigameResults
+          state={state}
+          onPlayAgain={mg.playAgain}
+          onDone={mg.reset}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Plus, BarChart3, Swords, User } from "lucide-react";
+import { Home, Plus, BarChart3, Swords, User, Dices } from "lucide-react";
 import { useUnsavedGuard } from "@/components/UnsavedGuard";
 
 const navItems = [
   { href: "/dashboard", label: "Home", icon: Home },
   { href: "/stats", label: "Stats", icon: BarChart3 },
   { href: "/leaderboard", label: "Ranked", icon: Swords },
+  { href: "/minigames", label: "Minigames", icon: Dices },
   { href: "/profile", label: "Me", icon: User },
 ];
 

--- a/src/components/minigame/MinigameBoard.tsx
+++ b/src/components/minigame/MinigameBoard.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { Undo2, Flag, ChevronRight, Crown } from "lucide-react";
+import {
+  type MinigameState,
+  type MinigameActionType,
+  TOTAL_FRAMES,
+  standings,
+  computeTotals,
+  currentGameIndex,
+  playerFrame,
+  tenthFrameClosed,
+} from "@/lib/minigame";
+import MinigameScorecard from "@/components/minigame/MinigameScorecard";
+
+interface Props {
+  state: MinigameState;
+  onEvent: (playerId: string, type: MinigameActionType) => void;
+  onUndo: (playerId: string) => void;
+  onAdvance: (playerId: string) => void;
+  onGoToFrame: (playerId: string, frameIndex: number) => void;
+  onEndGame: () => void;
+}
+
+function haptic(pattern: number | number[]) {
+  if (typeof navigator !== "undefined" && navigator.vibrate)
+    navigator.vibrate(pattern);
+}
+
+export default function MinigameBoard({
+  state,
+  onEvent,
+  onUndo,
+  onAdvance,
+  onGoToFrame,
+  onEndGame,
+}: Props) {
+  const { rules } = state;
+  const gameIndex = currentGameIndex(state);
+  const totals = computeTotals(state);
+  const ranked = standings(state);
+
+  function tap(playerId: string, type: MinigameActionType) {
+    haptic(type === "cornerMissed" ? 30 : [15, 40, 15]);
+    onEvent(playerId, type);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Game + running standings strip */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-bold">Game {gameIndex + 1}</span>
+        <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 text-xs">
+          {ranked.map((r) => {
+            const wins = state.games.filter(
+              (g) => g.winnerId === r.player.id,
+            ).length;
+            return (
+              <span
+                key={r.player.id}
+                className="inline-flex items-center gap-1 text-text-secondary"
+              >
+                {r.player.name}
+                <span className="font-bold tabular-nums text-text-primary">
+                  {r.total}
+                </span>
+                {Array.from({ length: wins }, (_, i) => (
+                  <Crown key={i} size={11} className="text-gold" />
+                ))}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Per-player scorecards + controls */}
+      <div className="flex flex-col gap-2">
+        {state.players.map((p) => {
+          const frame = playerFrame(state, p.id);
+          const isTenth = frame === TOTAL_FRAMES - 1;
+          const locked = isTenth && tenthFrameClosed(state, p.id, gameIndex);
+          const hasEventsThisGame = state.events.some(
+            (e) => e.playerId === p.id && e.gameIndex === gameIndex,
+          );
+          return (
+            <div key={p.id} className="glass p-3">
+              <div className="mb-2 flex items-center gap-2">
+                <span className="flex-1 truncate text-sm font-semibold text-text-primary">
+                  {p.name}
+                </span>
+                <span className="text-[11px] font-semibold text-text-muted">
+                  Frame {frame + 1}/{TOTAL_FRAMES}
+                </span>
+                <span className="text-xl font-extrabold tabular-nums">
+                  {totals[p.id]}
+                </span>
+              </div>
+
+              <div className="mb-3">
+                <MinigameScorecard
+                  state={state}
+                  playerId={p.id}
+                  gameIndex={gameIndex}
+                  currentFrame={frame}
+                  onFrameTap={(f) => onGoToFrame(p.id, f)}
+                />
+              </div>
+
+              {locked ? (
+                <div className="rounded-lg bg-surface-light py-2.5 text-center text-xs font-semibold text-text-muted">
+                  Frame 10 complete
+                </div>
+              ) : (
+                <div className="flex items-stretch gap-1.5">
+                  <ActionButton
+                    name="Strike"
+                    pts={rules.strikePoints}
+                    color="blue"
+                    onClick={() => tap(p.id, "strike")}
+                  />
+                  <ActionButton
+                    name="Spare"
+                    pts={rules.sparePoints}
+                    color="purple"
+                    onClick={() => tap(p.id, "spare")}
+                  />
+                  <ActionButton
+                    name="Corner"
+                    pts={rules.cornerPoints}
+                    color="green"
+                    onClick={() => tap(p.id, "cornerMade")}
+                  />
+                  <ActionButton
+                    name="Open"
+                    pts={rules.penaltyEnabled ? -rules.cornerMissPenalty : 0}
+                    color="red"
+                    onClick={() => tap(p.id, "cornerMissed")}
+                  />
+                  {!isTenth && (
+                    <button
+                      onClick={() => onAdvance(p.id)}
+                      aria-label={`Next frame for ${p.name}`}
+                      className="flex w-10 shrink-0 items-center justify-center rounded-lg bg-surface-light text-text-secondary active:scale-95"
+                    >
+                      <ChevronRight size={18} />
+                    </button>
+                  )}
+                </div>
+              )}
+
+              <button
+                onClick={() => onUndo(p.id)}
+                disabled={!hasEventsThisGame}
+                className="mt-2 flex items-center gap-1.5 text-[11px] font-semibold text-text-muted active:scale-95 disabled:opacity-30"
+              >
+                <Undo2 size={12} /> Undo last
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={onEndGame}
+        className="mt-1 flex items-center justify-center gap-2 rounded-xl border border-border bg-surface-light py-3.5 text-sm font-bold text-text-primary active:scale-[0.98]"
+      >
+        <Flag size={16} /> End game {gameIndex + 1}
+      </button>
+    </div>
+  );
+}
+
+const colorClasses: Record<string, string> = {
+  blue: "bg-blue/15 text-blue active:bg-blue/25",
+  purple: "bg-purple/15 text-purple active:bg-purple/25",
+  green: "bg-green/15 text-green active:bg-green/25",
+  red: "bg-red/15 text-red active:bg-red/25",
+};
+
+function formatPts(pts: number): string {
+  if (pts === 0) return "0";
+  return pts > 0 ? `+${pts}` : `−${Math.abs(pts)}`;
+}
+
+function ActionButton({
+  name,
+  pts,
+  color,
+  onClick,
+}: {
+  name: string;
+  pts: number;
+  color: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex flex-1 flex-col items-center gap-0.5 rounded-lg py-2 transition-all active:scale-95 ${colorClasses[color]}`}
+    >
+      <span className="text-[12px] font-bold leading-none">{name}</span>
+      <span className="text-[10px] font-bold leading-none opacity-70 tabular-nums">
+        {formatPts(pts)}
+      </span>
+    </button>
+  );
+}

--- a/src/components/minigame/MinigameResults.tsx
+++ b/src/components/minigame/MinigameResults.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Crown, RotateCcw, Check } from "lucide-react";
+import { type MinigameState, standings, playerSummary } from "@/lib/minigame";
+
+interface Props {
+  state: MinigameState;
+  onPlayAgain: () => void;
+  onDone: () => void;
+}
+
+const medal = ["text-gold", "text-text-secondary", "text-[#cd7f32]"];
+
+export default function MinigameResults({ state, onPlayAgain, onDone }: Props) {
+  const rows = standings(state);
+  const gamesPlayed = state.games.length;
+  const champion = rows[0];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Champion banner */}
+      <div className="glass-strong flex items-center gap-3 border border-gold/40 p-4">
+        <Crown size={28} className="text-gold" />
+        <div>
+          <div className="text-[11px] uppercase tracking-wide text-text-muted">
+            Winner · {gamesPlayed} game{gamesPlayed !== 1 ? "s" : ""}
+          </div>
+          <div className="text-lg font-extrabold">
+            {champion.player.name}{" "}
+            <span className="text-gold">· {champion.total} pts</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Standings */}
+      <section>
+        <h2 className="mb-2 text-sm font-bold">Final standings</h2>
+        <div className="flex flex-col gap-2">
+          {rows.map((row) => {
+            const s = playerSummary(state, row.player.id);
+            return (
+              <div
+                key={row.player.id}
+                className={`glass flex items-center gap-3 p-3 ${
+                  row.rank === 1 ? "border border-gold/40" : ""
+                }`}
+              >
+                <span
+                  className={`w-5 text-center text-sm font-extrabold ${medal[row.rank - 1] ?? "text-text-muted"}`}
+                >
+                  {row.rank}
+                </span>
+                <div className="flex-1">
+                  <span className="text-sm font-semibold text-text-primary">
+                    {row.player.name}
+                  </span>
+                  <div className="mt-0.5 text-[11px] text-text-muted">
+                    {s.gamesWon} won · {s.strikes} strikes · {s.spares} spares ·{" "}
+                    {s.cornerMade} corners
+                    {s.cornerMissed > 0 ? ` · ${s.cornerMissed} open` : ""}
+                  </div>
+                </div>
+                <span className="text-2xl font-extrabold tabular-nums">
+                  {row.total}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <div className="flex gap-2">
+        <button
+          onClick={onPlayAgain}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-surface-light py-3.5 text-sm font-bold text-text-primary active:scale-[0.98]"
+        >
+          <RotateCcw size={16} /> New session
+        </button>
+        <button
+          onClick={onDone}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue to-blue-dark py-3.5 text-sm font-bold text-white shadow-lg shadow-blue/25 active:scale-[0.98]"
+        >
+          <Check size={16} /> Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/minigame/MinigameScorecard.tsx
+++ b/src/components/minigame/MinigameScorecard.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { type MinigameState, TOTAL_FRAMES } from "@/lib/minigame";
+
+interface Props {
+  state: MinigameState;
+  playerId: string;
+  gameIndex: number;
+  currentFrame: number;
+  onFrameTap: (frameIndex: number) => void;
+}
+
+interface FrameCell {
+  strikes: number;
+  spares: number;
+  cornerMade: number;
+  cornerMissed: number;
+  points: number;
+}
+
+// Build a per-frame breakdown for this player + game from the event log.
+function buildFrames(
+  state: MinigameState,
+  playerId: string,
+  gameIndex: number,
+): FrameCell[] {
+  const cells: FrameCell[] = Array.from({ length: TOTAL_FRAMES }, () => ({
+    strikes: 0,
+    spares: 0,
+    cornerMade: 0,
+    cornerMissed: 0,
+    points: 0,
+  }));
+  for (const e of state.events) {
+    if (e.playerId !== playerId || e.gameIndex !== gameIndex) continue;
+    if (e.frameIndex < 0 || e.frameIndex >= TOTAL_FRAMES) continue;
+    const c = cells[e.frameIndex];
+    if (e.type === "strike") c.strikes++;
+    else if (e.type === "spare") c.spares++;
+    else if (e.type === "cornerMade") c.cornerMade++;
+    else if (e.type === "cornerMissed") c.cornerMissed++;
+    c.points += e.points;
+  }
+  return cells;
+}
+
+function Glyph({
+  char,
+  count,
+  className,
+}: {
+  char: string;
+  count: number;
+  className: string;
+}) {
+  if (count === 0) return null;
+  return (
+    <span className={`font-bold ${className}`}>
+      {char}
+      {count > 1 ? <span className="text-[7px]">{count}</span> : null}
+    </span>
+  );
+}
+
+export default function MinigameScorecard({
+  state,
+  playerId,
+  gameIndex,
+  currentFrame,
+  onFrameTap,
+}: Props) {
+  const cells = buildFrames(state, playerId, gameIndex);
+  const cumulative: number[] = [];
+  cells.reduce((sum, c) => {
+    const next = sum + c.points;
+    cumulative.push(next);
+    return next;
+  }, 0);
+  const lastFrameWithEvents = cells.reduce(
+    (max, c, i) =>
+      c.strikes || c.spares || c.cornerMade || c.cornerMissed ? i : max,
+    -1,
+  );
+
+  return (
+    <div className="glass overflow-hidden rounded-lg">
+      <table className="w-full table-fixed border-collapse text-center">
+        <thead>
+          <tr>
+            {cells.map((_, i) => (
+              <th
+                key={i}
+                style={{ width: "10%" }}
+                className="border border-border py-[2px] text-[8px] font-normal text-text-muted"
+              >
+                {i + 1}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {/* Marks */}
+          <tr className="h-[24px]">
+            {cells.map((c, i) => {
+              const has =
+                c.strikes || c.spares || c.cornerMade || c.cornerMissed;
+              return (
+                <td
+                  key={i}
+                  onClick={() => onFrameTap(i)}
+                  className={`cursor-pointer border border-border align-middle text-[10px] leading-none ${
+                    i === currentFrame ? "bg-blue/15" : "active:bg-blue/5"
+                  }`}
+                >
+                  <div className="flex flex-wrap items-center justify-center gap-x-0.5">
+                    <Glyph char="X" count={c.strikes} className="text-blue" />
+                    <Glyph char="/" count={c.spares} className="text-purple" />
+                    <Glyph
+                      char="◎"
+                      count={c.cornerMade}
+                      className="text-green"
+                    />
+                    <Glyph
+                      char="−"
+                      count={c.cornerMissed}
+                      className="text-red"
+                    />
+                    {!has && i === currentFrame ? (
+                      <span className="animate-pulse text-blue">_</span>
+                    ) : null}
+                  </div>
+                </td>
+              );
+            })}
+          </tr>
+          {/* Cumulative points */}
+          <tr className="h-[20px]">
+            {cells.map((_, i) => {
+              const show = i <= lastFrameWithEvents;
+              return (
+                <td
+                  key={i}
+                  className="border border-border text-[10px] font-bold tabular-nums text-text-primary"
+                >
+                  {show ? (
+                    cumulative[i]
+                  ) : (
+                    <span className="text-text-muted/40">·</span>
+                  )}
+                </td>
+              );
+            })}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/minigame/MinigameSetup.tsx
+++ b/src/components/minigame/MinigameSetup.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, X, Play } from "lucide-react";
+import {
+  type MinigameRules,
+  type MinigamePlayer,
+  PRESETS,
+  DEFAULT_RULES,
+  rulesFromPreset,
+} from "@/lib/minigame";
+
+interface Props {
+  onStart: (next: { players: MinigamePlayer[]; rules: MinigameRules }) => void;
+}
+
+let pidCounter = 0;
+function makePlayer(name: string): MinigamePlayer {
+  pidCounter += 1;
+  return { id: `p-${pidCounter}-${name}`, name };
+}
+
+export default function MinigameSetup({ onStart }: Props) {
+  const [names, setNames] = useState<string[]>(["", ""]);
+  const [rules, setRules] = useState<MinigameRules>({ ...DEFAULT_RULES });
+  const [activePreset, setActivePreset] = useState<string | null>("2-2-3");
+
+  const validNames = names.map((n) => n.trim()).filter(Boolean);
+  const canStart = validNames.length >= 2;
+
+  function updateName(i: number, value: string) {
+    setNames((prev) => prev.map((n, idx) => (idx === i ? value : n)));
+  }
+
+  function setRuleValue(key: keyof MinigameRules, value: number) {
+    setRules((r) => ({ ...r, [key]: value }));
+    setActivePreset(null);
+  }
+
+  function applyPreset(id: string) {
+    const preset = PRESETS.find((p) => p.id === id);
+    if (!preset) return;
+    setRules((r) => rulesFromPreset(preset, r));
+    setActivePreset(id);
+  }
+
+  function start() {
+    if (!canStart) return;
+    onStart({ players: validNames.map(makePlayer), rules });
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Players */}
+      <section>
+        <h2 className="mb-2 text-sm font-bold">Players</h2>
+        <div className="flex flex-col gap-2">
+          {names.map((name, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                value={name}
+                onChange={(e) => updateName(i, e.target.value)}
+                placeholder={`Player ${i + 1}`}
+                className="glass flex-1 rounded-xl px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-blue/40"
+              />
+              {names.length > 2 && (
+                <button
+                  onClick={() =>
+                    setNames((prev) => prev.filter((_, idx) => idx !== i))
+                  }
+                  aria-label={`Remove player ${i + 1}`}
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-text-muted active:scale-95"
+                >
+                  <X size={18} />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        <button
+          onClick={() => setNames((prev) => [...prev, ""])}
+          className="mt-2 flex items-center gap-2 rounded-xl px-2 py-2 text-sm font-semibold text-blue active:scale-95"
+        >
+          <Plus size={16} strokeWidth={2.5} /> Add player
+        </button>
+      </section>
+
+      {/* Scoring rules */}
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h2 className="text-sm font-bold">Scoring</h2>
+          <div className="flex items-center gap-1.5">
+            {PRESETS.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => applyPreset(p.id)}
+                className={`rounded-lg px-2.5 py-1 text-xs font-bold transition-all active:scale-95 ${
+                  activePreset === p.id
+                    ? "bg-blue/15 text-blue"
+                    : "bg-surface-light text-text-secondary"
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+            {activePreset === null && (
+              <span className="rounded-lg bg-purple/15 px-2.5 py-1 text-xs font-bold text-purple">
+                Custom
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="glass flex flex-col divide-y divide-border">
+          <RuleRow
+            label="Strike"
+            value={rules.strikePoints}
+            onChange={(v) => setRuleValue("strikePoints", v)}
+          />
+          <RuleRow
+            label="Spare"
+            value={rules.sparePoints}
+            onChange={(v) => setRuleValue("sparePoints", v)}
+          />
+          <RuleRow
+            label="Corner pin (7 / 10)"
+            value={rules.cornerPoints}
+            onChange={(v) => setRuleValue("cornerPoints", v)}
+          />
+          <RuleRow
+            label="Overall winner"
+            value={rules.winnerPoints}
+            onChange={(v) => setRuleValue("winnerPoints", v)}
+          />
+        </div>
+
+        {/* Miss penalty toggle — tappable card (matches app toggle pattern) */}
+        <button
+          type="button"
+          aria-pressed={rules.penaltyEnabled}
+          onClick={() =>
+            setRules((r) => ({ ...r, penaltyEnabled: !r.penaltyEnabled }))
+          }
+          className="glass mt-3 flex w-full items-center gap-3 p-4 text-left active:scale-[0.99]"
+        >
+          <div className="flex-1">
+            <span className="block text-sm font-semibold text-white">
+              Open frame penalty
+            </span>
+            <span className="text-xs text-text-secondary">
+              {rules.penaltyEnabled
+                ? `Open frame costs −${rules.cornerMissPenalty}`
+                : "Open marks the frame but costs nothing"}
+            </span>
+          </div>
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-bold ${
+              rules.penaltyEnabled
+                ? "bg-red/15 text-red"
+                : "bg-surface-light text-text-muted"
+            }`}
+          >
+            {rules.penaltyEnabled ? "ON" : "OFF"}
+          </span>
+        </button>
+      </section>
+
+      <button
+        onClick={start}
+        disabled={!canStart}
+        className="flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue to-blue-dark py-4 text-base font-bold text-white shadow-lg shadow-blue/25 transition-all active:scale-[0.97] disabled:opacity-40 disabled:active:scale-100"
+      >
+        <Play size={18} fill="white" /> Start game
+      </button>
+      {!canStart && (
+        <p className="-mt-2 text-center text-xs text-text-muted">
+          Add at least 2 players to start
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RuleRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3">
+      <span className="text-sm font-medium text-text-primary">{label}</span>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => onChange(Math.max(0, value - 1))}
+          aria-label={`Decrease ${label}`}
+          className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-light text-lg font-bold leading-none text-white active:scale-95"
+        >
+          −
+        </button>
+        <span className="w-6 text-center text-base font-bold tabular-nums text-white">
+          {value}
+        </span>
+        <button
+          onClick={() => onChange(value + 1)}
+          aria-label={`Increase ${label}`}
+          className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-light text-lg font-bold leading-none text-white active:scale-95"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/minigame/MinigameWinnerPicker.tsx
+++ b/src/components/minigame/MinigameWinnerPicker.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { Crown, ArrowRight, Check, X } from "lucide-react";
+import { type MinigameState, currentGameIndex } from "@/lib/minigame";
+
+interface Props {
+  state: MinigameState;
+  onConfirm: (winnerId: string | null, endSession: boolean) => void;
+  onCancel: () => void;
+}
+
+export default function MinigameWinnerPicker({
+  state,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [winnerId, setWinnerId] = useState<string | null>(null);
+  const gameNumber = currentGameIndex(state) + 1;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-end justify-center bg-black/70 p-4 backdrop-blur-sm sm:items-center">
+      <div className="w-full max-w-[440px] animate-slide-up rounded-2xl border border-border-light bg-surface p-5 shadow-2xl shadow-black/50">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-1.5">
+              <Crown size={18} className="text-gold" />
+              <h2 className="text-base font-extrabold text-white">
+                Who won Game {gameNumber}?
+              </h2>
+            </div>
+            <p className="mt-1 text-xs text-text-secondary">
+              Awards +{state.rules.winnerPoints}. Leave unselected for a tie.
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            aria-label="Back to game"
+            className="shrink-0 text-text-muted active:scale-95"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="mb-5 flex flex-wrap gap-2">
+          {state.players.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => setWinnerId((cur) => (cur === p.id ? null : p.id))}
+              className={`flex items-center gap-1.5 rounded-full border px-4 py-2 text-sm font-semibold transition-all active:scale-95 ${
+                winnerId === p.id
+                  ? "border-gold bg-gold/20 text-gold"
+                  : "border-border-light bg-surface-light text-white"
+              }`}
+            >
+              {winnerId === p.id && <Crown size={14} className="text-gold" />}
+              {p.name}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            onClick={() => onConfirm(winnerId, false)}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue to-blue-dark py-3.5 text-sm font-bold text-white shadow-lg shadow-blue/25 active:scale-[0.98]"
+          >
+            Next game <ArrowRight size={16} />
+          </button>
+          <button
+            onClick={() => onConfirm(winnerId, true)}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-border-light bg-surface-light py-3.5 text-sm font-bold text-white active:scale-[0.98]"
+          >
+            <Check size={16} /> Finish session
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useMinigameState.ts
+++ b/src/hooks/useMinigameState.ts
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  type MinigameState,
+  type MinigameActionType,
+  type MinigamePlayer,
+  DEFAULT_RULES,
+  TOTAL_FRAMES,
+  actionPoints,
+  currentGameIndex,
+  endsFrame,
+  tenthFrameClosed,
+} from "@/lib/minigame";
+
+// Bump on any state/rules shape change so older saves are ignored instead of
+// producing crashes or undefined points. v4 = per-player frames (frameByPlayer).
+const STORAGE_KEY = "spare-me-minigame-v4";
+
+function emptyState(): MinigameState {
+  return {
+    step: "setup",
+    rules: { ...DEFAULT_RULES },
+    players: [],
+    events: [],
+    games: [],
+    frameByPlayer: {},
+    pickingWinner: false,
+  };
+}
+
+// Guard against malformed or outdated persisted state.
+function isValidState(s: unknown): s is MinigameState {
+  if (!s || typeof s !== "object") return false;
+  const o = s as Record<string, unknown>;
+  return (
+    Array.isArray(o.players) &&
+    Array.isArray(o.events) &&
+    Array.isArray(o.games) &&
+    typeof o.rules === "object" &&
+    o.rules !== null &&
+    typeof o.frameByPlayer === "object" &&
+    o.frameByPlayer !== null
+  );
+}
+
+function loadState(): MinigameState {
+  if (typeof window === "undefined") return emptyState();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyState();
+    const parsed = JSON.parse(raw);
+    return isValidState(parsed) ? parsed : emptyState();
+  } catch {
+    return emptyState();
+  }
+}
+
+function freshFrames(players: MinigamePlayer[]): Record<string, number> {
+  return Object.fromEntries(players.map((p) => [p.id, 0]));
+}
+
+// Local-only minigame state, auto-persisted so an in-progress session survives a
+// reload (mirrors the bowling-session autosave pattern). No DB, no LP.
+export function useMinigameState() {
+  const [state, setState] = useState<MinigameState>(emptyState);
+  const [hydrated, setHydrated] = useState(false);
+  const idRef = useRef(0);
+
+  // Hydrate from localStorage after mount to avoid SSR mismatch.
+  useEffect(() => {
+    setState(loadState());
+    setHydrated(true);
+  }, []);
+
+  // Persist on every change once hydrated.
+  useEffect(() => {
+    if (!hydrated) return;
+    if (state.step === "setup" && state.players.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    }
+  }, [state, hydrated]);
+
+  function newEventId() {
+    idRef.current += 1;
+    return `evt-${idRef.current}`;
+  }
+
+  function startGame(next: Pick<MinigameState, "players" | "rules">) {
+    setState({
+      step: "playing",
+      rules: next.rules,
+      players: next.players,
+      events: [],
+      games: [],
+      frameByPlayer: freshFrames(next.players),
+      pickingWinner: false,
+    });
+  }
+
+  function addEvent(playerId: string, type: MinigameActionType) {
+    setState((s) => {
+      const frame = s.frameByPlayer[playerId] ?? 0;
+      const gi = currentGameIndex(s);
+      // 10th frame: max 3 inputs, and an Open ends it (no further inputs).
+      if (frame === TOTAL_FRAMES - 1 && tenthFrameClosed(s, playerId, gi)) {
+        return s;
+      }
+      // Corner and Open can each only be logged once per frame — except the
+      // 10th frame, which has bonus balls and behaves like a normal last frame.
+      if (
+        (type === "cornerMade" || type === "cornerMissed") &&
+        frame < TOTAL_FRAMES - 1 &&
+        s.events.some(
+          (e) =>
+            e.playerId === playerId &&
+            e.gameIndex === gi &&
+            e.frameIndex === frame &&
+            e.type === type,
+        )
+      ) {
+        return s;
+      }
+      const event = {
+        id: newEventId(),
+        gameIndex: gi,
+        frameIndex: frame,
+        playerId,
+        type,
+        points: actionPoints(type, s.rules),
+      };
+      // Strike / Spare / Miss complete the frame; Corner waits for a possible Miss.
+      const nextFrame = endsFrame(type)
+        ? Math.min(TOTAL_FRAMES - 1, frame + 1)
+        : frame;
+      return {
+        ...s,
+        events: [...s.events, event],
+        frameByPlayer: { ...s.frameByPlayer, [playerId]: nextFrame },
+      };
+    });
+  }
+
+  // Manual advance — used to bank a made corner (which doesn't auto-advance).
+  function advancePlayer(playerId: string) {
+    setState((s) => ({
+      ...s,
+      frameByPlayer: {
+        ...s.frameByPlayer,
+        [playerId]: Math.min(
+          TOTAL_FRAMES - 1,
+          (s.frameByPlayer[playerId] ?? 0) + 1,
+        ),
+      },
+    }));
+  }
+
+  function goToFrame(playerId: string, frameIndex: number) {
+    setState((s) => ({
+      ...s,
+      frameByPlayer: {
+        ...s.frameByPlayer,
+        [playerId]: Math.max(0, Math.min(TOTAL_FRAMES - 1, frameIndex)),
+      },
+    }));
+  }
+
+  // Remove a player's most recent event and return them to that frame.
+  function undoPlayer(playerId: string) {
+    setState((s) => {
+      const gi = currentGameIndex(s);
+      for (let i = s.events.length - 1; i >= 0; i--) {
+        const e = s.events[i];
+        if (e.playerId === playerId && e.gameIndex === gi) {
+          return {
+            ...s,
+            events: s.events.filter((_, idx) => idx !== i),
+            frameByPlayer: { ...s.frameByPlayer, [playerId]: e.frameIndex },
+          };
+        }
+      }
+      return s;
+    });
+  }
+
+  function requestEndGame() {
+    setState((s) => ({ ...s, pickingWinner: true }));
+  }
+
+  function cancelEndGame() {
+    setState((s) => ({ ...s, pickingWinner: false }));
+  }
+
+  // Record the current game's winner, then either start the next game or end
+  // the whole session.
+  function finishGame(winnerId: string | null, endSession: boolean) {
+    setState((s) => ({
+      ...s,
+      games: [...s.games, { winnerId }],
+      frameByPlayer: freshFrames(s.players),
+      pickingWinner: false,
+      step: endSession ? "finished" : "playing",
+    }));
+  }
+
+  // Fresh session, same players + rules.
+  function playAgain() {
+    setState((s) => ({
+      ...s,
+      step: "playing",
+      events: [],
+      games: [],
+      frameByPlayer: freshFrames(s.players),
+      pickingWinner: false,
+    }));
+  }
+
+  function reset() {
+    setState(emptyState());
+  }
+
+  return {
+    state,
+    hydrated,
+    startGame,
+    addEvent,
+    advancePlayer,
+    goToFrame,
+    undoPlayer,
+    requestEndGame,
+    cancelEndGame,
+    finishGame,
+    playAgain,
+    reset,
+  };
+}

--- a/src/lib/minigame.test.ts
+++ b/src/lib/minigame.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import {
+  actionPoints,
+  computeTotals,
+  standings,
+  frameCounts,
+  playerSummary,
+  rulesFromPreset,
+  currentGameIndex,
+  endsFrame,
+  tenthFrameClosed,
+  PRESETS,
+  DEFAULT_RULES,
+  type MinigameState,
+  type MinigameEvent,
+} from "./minigame";
+
+let seq = 0;
+function evt(
+  playerId: string,
+  type: MinigameEvent["type"],
+  points: number,
+  gameIndex = 0,
+  frameIndex = 0,
+): MinigameEvent {
+  seq += 1;
+  return { id: `e-${seq}`, playerId, type, points, gameIndex, frameIndex };
+}
+
+function baseState(overrides: Partial<MinigameState> = {}): MinigameState {
+  return {
+    step: "playing",
+    rules: { ...DEFAULT_RULES },
+    players: [
+      { id: "a", name: "Alice" },
+      { id: "b", name: "Bob" },
+    ],
+    events: [],
+    games: [],
+    frameByPlayer: { a: 0, b: 0 },
+    pickingWinner: false,
+    ...overrides,
+  };
+}
+
+describe("actionPoints", () => {
+  it("returns rule values for strike and corner made", () => {
+    expect(actionPoints("strike", DEFAULT_RULES)).toBe(2);
+    expect(actionPoints("cornerMade", DEFAULT_RULES)).toBe(2);
+  });
+
+  it("returns the spare points (0 by default — a marker)", () => {
+    expect(actionPoints("spare", DEFAULT_RULES)).toBe(0);
+    expect(actionPoints("spare", { ...DEFAULT_RULES, sparePoints: 1 })).toBe(1);
+  });
+
+  it("returns 0 for a missed corner when penalty is off", () => {
+    expect(actionPoints("cornerMissed", DEFAULT_RULES)).toBe(0);
+  });
+
+  it("returns negative penalty for a missed corner when penalty is on", () => {
+    const rules = {
+      ...DEFAULT_RULES,
+      penaltyEnabled: true,
+      cornerMissPenalty: 1,
+    };
+    expect(actionPoints("cornerMissed", rules)).toBe(-1);
+  });
+});
+
+describe("endsFrame", () => {
+  it("ends the frame on strike, spare, and miss", () => {
+    expect(endsFrame("strike")).toBe(true);
+    expect(endsFrame("spare")).toBe(true);
+    expect(endsFrame("cornerMissed")).toBe(true);
+  });
+
+  it("does NOT end the frame on a made corner (a miss may follow)", () => {
+    expect(endsFrame("cornerMade")).toBe(false);
+  });
+});
+
+describe("tenthFrameClosed", () => {
+  const TENTH = 9;
+  it("is open until 3 inputs", () => {
+    const s = baseState({
+      events: [
+        evt("a", "strike", 2, 0, TENTH),
+        evt("a", "strike", 2, 0, TENTH),
+      ],
+    });
+    expect(tenthFrameClosed(s, "a", 0)).toBe(false);
+  });
+
+  it("closes at 3 inputs", () => {
+    const s = baseState({
+      events: [
+        evt("a", "strike", 2, 0, TENTH),
+        evt("a", "cornerMade", 2, 0, TENTH),
+        evt("a", "spare", 0, 0, TENTH),
+      ],
+    });
+    expect(tenthFrameClosed(s, "a", 0)).toBe(true);
+  });
+
+  it("closes immediately on an open", () => {
+    const s = baseState({
+      events: [
+        evt("a", "cornerMade", 2, 0, TENTH),
+        evt("a", "cornerMissed", -1, 0, TENTH),
+      ],
+    });
+    expect(tenthFrameClosed(s, "a", 0)).toBe(true);
+  });
+});
+
+describe("currentGameIndex", () => {
+  it("equals the number of completed games", () => {
+    expect(currentGameIndex(baseState())).toBe(0);
+    expect(currentGameIndex(baseState({ games: [{ winnerId: "a" }] }))).toBe(1);
+  });
+});
+
+describe("computeTotals", () => {
+  it("sums event points per player across frames and games", () => {
+    const state = baseState({
+      events: [
+        evt("a", "strike", 2, 0, 0),
+        evt("a", "cornerMade", 2, 0, 3),
+        evt("a", "strike", 2, 1, 5),
+        evt("b", "strike", 2, 0, 0),
+      ],
+    });
+    const totals = computeTotals(state);
+    expect(totals.a).toBe(6);
+    expect(totals.b).toBe(2);
+  });
+
+  it("adds the winner bonus for each game won", () => {
+    const state = baseState({
+      events: [evt("a", "strike", 2, 0, 0)],
+      games: [{ winnerId: "b" }, { winnerId: "b" }],
+    });
+    const totals = computeTotals(state);
+    expect(totals.a).toBe(2);
+    expect(totals.b).toBe(6); // two game wins x +3
+  });
+
+  it("ignores winner bonus for a tied game (null winner)", () => {
+    const state = baseState({ games: [{ winnerId: null }] });
+    expect(computeTotals(state).a).toBe(0);
+  });
+
+  it("can go negative with miss penalties", () => {
+    const state = baseState({
+      events: [
+        evt("a", "cornerMissed", -1, 0, 0),
+        evt("a", "cornerMissed", -1, 0, 1),
+      ],
+    });
+    expect(computeTotals(state).a).toBe(-2);
+  });
+});
+
+describe("standings", () => {
+  it("sorts by total descending", () => {
+    const state = baseState({
+      events: [evt("b", "strike", 2), evt("b", "strike", 2)],
+    });
+    const result = standings(state);
+    expect(result[0].player.id).toBe("b");
+    expect(result[0].rank).toBe(1);
+    expect(result[1].rank).toBe(2);
+  });
+
+  it("assigns shared rank on ties and keeps entry order", () => {
+    const result = standings(baseState());
+    expect(result[0].rank).toBe(1);
+    expect(result[1].rank).toBe(1);
+    expect(result.map((r) => r.player.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("frameCounts", () => {
+  it("counts a player's events in a specific game + frame", () => {
+    const state = baseState({
+      events: [
+        evt("a", "strike", 2, 0, 0),
+        evt("a", "strike", 2, 0, 0),
+        evt("a", "cornerMade", 2, 0, 1),
+        evt("a", "strike", 2, 1, 0),
+      ],
+    });
+    expect(frameCounts(state, "a", 0, 0)).toEqual({
+      strikes: 2,
+      spares: 0,
+      cornerMade: 0,
+      cornerMissed: 0,
+    });
+    expect(frameCounts(state, "a", 0, 1)).toEqual({
+      strikes: 0,
+      spares: 0,
+      cornerMade: 1,
+      cornerMissed: 0,
+    });
+  });
+
+  it("stacks corner + miss within one frame (the +2 −1 case)", () => {
+    const rules = {
+      ...DEFAULT_RULES,
+      penaltyEnabled: true,
+      cornerMissPenalty: 1,
+    };
+    const state = baseState({
+      rules,
+      events: [
+        evt("a", "cornerMade", 2, 0, 2),
+        evt("a", "cornerMissed", -1, 0, 2),
+      ],
+    });
+    expect(frameCounts(state, "a", 0, 2)).toEqual({
+      strikes: 0,
+      spares: 0,
+      cornerMade: 1,
+      cornerMissed: 1,
+    });
+    expect(computeTotals(state).a).toBe(1);
+  });
+
+  it("counts a whole game when frameIndex omitted", () => {
+    const state = baseState({
+      events: [
+        evt("a", "strike", 2, 0, 0),
+        evt("a", "spare", 0, 0, 3),
+        evt("a", "strike", 2, 1, 0),
+      ],
+    });
+    expect(frameCounts(state, "a", 0)).toEqual({
+      strikes: 1,
+      spares: 1,
+      cornerMade: 0,
+      cornerMissed: 0,
+    });
+  });
+});
+
+describe("playerSummary", () => {
+  it("totals events across the session and counts games won", () => {
+    const state = baseState({
+      events: [
+        evt("a", "strike", 2, 0, 0),
+        evt("a", "strike", 2, 1, 0),
+        evt("a", "cornerMade", 2, 0, 3),
+        evt("a", "cornerMissed", 0, 1, 5),
+      ],
+      games: [{ winnerId: "a" }, { winnerId: "b" }],
+    });
+    expect(playerSummary(state, "a")).toEqual({
+      strikes: 2,
+      spares: 0,
+      cornerMade: 1,
+      cornerMissed: 1,
+      gamesWon: 1,
+    });
+  });
+});
+
+describe("rulesFromPreset", () => {
+  it("applies preset point values while preserving penalty settings", () => {
+    const base = {
+      ...DEFAULT_RULES,
+      penaltyEnabled: true,
+      cornerMissPenalty: 2,
+    };
+    const preset = PRESETS.find((p) => p.id === "1-1-2")!;
+    const rules = rulesFromPreset(preset, base);
+    expect(rules.strikePoints).toBe(1);
+    expect(rules.cornerPoints).toBe(1);
+    expect(rules.winnerPoints).toBe(2);
+    expect(rules.penaltyEnabled).toBe(true);
+    expect(rules.cornerMissPenalty).toBe(2);
+  });
+});

--- a/src/lib/minigame.ts
+++ b/src/lib/minigame.ts
@@ -1,0 +1,241 @@
+// Casual minigame scoring engine ("2-2-3" and variants)
+//
+// A lightweight side-game played during casual bowling, structured like a real
+// session: multiple games, 10 frames each. Per frame you log each player's
+// minigame events (strike / corner-pin made / corner-pin missed). The winner of
+// each game earns a bonus. Points accumulate across all games. No LP/ranking.
+
+export const TOTAL_FRAMES = 10;
+
+export interface MinigameRules {
+  strikePoints: number;
+  sparePoints: number; // usually 0 — a bowling-format marker
+  cornerPoints: number;
+  winnerPoints: number;
+  // When true, the Miss button is shown and subtracts cornerMissPenalty.
+  penaltyEnabled: boolean;
+  cornerMissPenalty: number;
+}
+
+export type MinigameActionType =
+  | "strike"
+  | "spare"
+  | "cornerMade"
+  | "cornerMissed";
+
+export interface MinigameEvent {
+  id: string;
+  gameIndex: number;
+  frameIndex: number; // 0-based, 0..9
+  playerId: string;
+  type: MinigameActionType;
+  points: number;
+}
+
+// One completed game. winnerId gets the winner bonus; null = tie / no winner.
+export interface GameResult {
+  winnerId: string | null;
+}
+
+export interface MinigamePlayer {
+  id: string;
+  name: string;
+}
+
+export type MinigameStep = "setup" | "playing" | "finished";
+
+export interface MinigameState {
+  step: MinigameStep;
+  rules: MinigameRules;
+  players: MinigamePlayer[];
+  events: MinigameEvent[];
+  games: GameResult[]; // completed games
+  frameByPlayer: Record<string, number>; // each player's current frame (0..9) in the in-progress game
+  pickingWinner: boolean; // showing the winner picker for the current game
+}
+
+// Whether logging this event completes the player's frame (auto-advance).
+// A made corner does NOT end the frame — a Miss may follow it (corner + miss).
+export function endsFrame(type: MinigameActionType): boolean {
+  return type === "strike" || type === "spare" || type === "cornerMissed";
+}
+
+// A player's current frame index, defaulting to 0.
+export function playerFrame(state: MinigameState, playerId: string): number {
+  return state.frameByPlayer[playerId] ?? 0;
+}
+
+export const TENTH_FRAME_MAX_INPUTS = 3;
+
+// The 10th frame is closed once it has 3 inputs, or an Open (which ends the
+// frame with no bonus ball). No more inputs may be logged after that.
+export function tenthFrameClosed(
+  state: MinigameState,
+  playerId: string,
+  gameIndex: number,
+): boolean {
+  let count = 0;
+  let hasOpen = false;
+  for (const e of state.events) {
+    if (e.playerId !== playerId || e.gameIndex !== gameIndex) continue;
+    if (e.frameIndex !== TOTAL_FRAMES - 1) continue;
+    count++;
+    if (e.type === "cornerMissed") hasOpen = true;
+  }
+  return hasOpen || count >= TENTH_FRAME_MAX_INPUTS;
+}
+
+export interface MinigamePreset {
+  id: string;
+  label: string;
+  strikePoints: number;
+  cornerPoints: number;
+  winnerPoints: number;
+}
+
+export const PRESETS: MinigamePreset[] = [
+  {
+    id: "2-2-3",
+    label: "2-2-3",
+    strikePoints: 2,
+    cornerPoints: 2,
+    winnerPoints: 3,
+  },
+  {
+    id: "1-1-2",
+    label: "1-1-2",
+    strikePoints: 1,
+    cornerPoints: 1,
+    winnerPoints: 2,
+  },
+];
+
+export const DEFAULT_RULES: MinigameRules = {
+  strikePoints: 2,
+  sparePoints: 0,
+  cornerPoints: 2,
+  winnerPoints: 3,
+  penaltyEnabled: false,
+  cornerMissPenalty: 1,
+};
+
+// The game currently being played (= number of completed games).
+export function currentGameIndex(state: MinigameState): number {
+  return state.games.length;
+}
+
+// Points an event is worth under the given rules. Misses are negative.
+export function actionPoints(
+  type: MinigameActionType,
+  rules: MinigameRules,
+): number {
+  switch (type) {
+    case "strike":
+      return rules.strikePoints;
+    case "spare":
+      return rules.sparePoints;
+    case "cornerMade":
+      return rules.cornerPoints;
+    case "cornerMissed":
+      return rules.penaltyEnabled ? -rules.cornerMissPenalty : 0;
+  }
+}
+
+// Total points per player: all event points + winner bonus for each game won.
+export function computeTotals(state: MinigameState): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const p of state.players) totals[p.id] = 0;
+
+  for (const e of state.events) {
+    if (e.playerId in totals) totals[e.playerId] += e.points;
+  }
+
+  for (const g of state.games) {
+    if (g.winnerId && g.winnerId in totals)
+      totals[g.winnerId] += state.rules.winnerPoints;
+  }
+
+  return totals;
+}
+
+// Players sorted by total points descending (stable on entry order for ties).
+export function standings(
+  state: MinigameState,
+): Array<{ player: MinigamePlayer; total: number; rank: number }> {
+  const totals = computeTotals(state);
+  const ordered = state.players
+    .map((player, index) => ({ player, total: totals[player.id], index }))
+    .sort((a, b) => b.total - a.total || a.index - b.index);
+
+  let lastTotal: number | null = null;
+  let lastRank = 0;
+  return ordered.map((row, i) => {
+    const rank = lastTotal === row.total ? lastRank : i + 1;
+    lastTotal = row.total;
+    lastRank = rank;
+    return { player: row.player, total: row.total, rank };
+  });
+}
+
+// Event counts for one player within a specific game + frame (for the live
+// per-frame chips). Omit frameIndex to count the whole game.
+export function frameCounts(
+  state: MinigameState,
+  playerId: string,
+  gameIndex: number,
+  frameIndex?: number,
+): {
+  strikes: number;
+  spares: number;
+  cornerMade: number;
+  cornerMissed: number;
+} {
+  let strikes = 0;
+  let spares = 0;
+  let cornerMade = 0;
+  let cornerMissed = 0;
+  for (const e of state.events) {
+    if (e.playerId !== playerId || e.gameIndex !== gameIndex) continue;
+    if (frameIndex !== undefined && e.frameIndex !== frameIndex) continue;
+    if (e.type === "strike") strikes++;
+    else if (e.type === "spare") spares++;
+    else if (e.type === "cornerMade") cornerMade++;
+    else if (e.type === "cornerMissed") cornerMissed++;
+  }
+  return { strikes, spares, cornerMade, cornerMissed };
+}
+
+// Whole-session breakdown for one player, including games won.
+export function playerSummary(
+  state: MinigameState,
+  playerId: string,
+): {
+  strikes: number;
+  spares: number;
+  cornerMade: number;
+  cornerMissed: number;
+  gamesWon: number;
+} {
+  const totals = { strikes: 0, spares: 0, cornerMade: 0, cornerMissed: 0 };
+  for (const e of state.events) {
+    if (e.playerId !== playerId) continue;
+    if (e.type === "strike") totals.strikes++;
+    else if (e.type === "spare") totals.spares++;
+    else if (e.type === "cornerMade") totals.cornerMade++;
+    else if (e.type === "cornerMissed") totals.cornerMissed++;
+  }
+  const gamesWon = state.games.filter((g) => g.winnerId === playerId).length;
+  return { ...totals, gamesWon };
+}
+
+export function rulesFromPreset(
+  preset: MinigamePreset,
+  base: MinigameRules,
+): MinigameRules {
+  return {
+    ...base,
+    strikePoints: preset.strikePoints,
+    cornerPoints: preset.cornerPoints,
+    winnerPoints: preset.winnerPoints,
+  };
+}


### PR DESCRIPTION
Adds a **Minigames** section — a casual bowling scoring side-game (2-2-3 and variants) played alongside normal bowling, fully independent of LP/ranking.

## What it does
- Per-player bowling-style **scorecards**, frame by frame, across multiple games in a session
- Events: **Strike** / **Spare** / **Corner** (+points) / **Open** (penalty, optional toggle)
- **Strike/Spare/Open auto-advance** the frame; **Corner waits** (so corner→open nets +2−1)
- Corner and Open capped **once per frame**; the **10th frame allows up to 3 inputs** and an **Open ends it** (no bonus ball)
- **Per-game winner bonus** (+3), with crowns shown per win in the standings and winner picker
- **localStorage autosave** — an in-progress session survives reload; no DB writes
- Entry points: dashboard card + desktop SideNav item

## Tests
- New `src/lib/minigame.ts` scoring engine with unit tests
- Full suite: 77 passing, `tsc` clean, lint clean